### PR TITLE
Readme: update GraphQLServerOptions to include rootValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ npm install --save fastify-apollo graphql
 ## Register plugin
 ```js
 fastify.register(require("fastify-apollo"), {
-    graphql: { schema },
+    graphql: { schema, rootValue },
     graphiql: true
 });
 ```
@@ -44,9 +44,9 @@ options.prefix = "/api"
 ```
 
 ### GraphQL
-Extends [GraphQLServerOptions](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-core/src/graphqlOptions.ts#L4-L28) from Apollo.
+Extends [GraphQLServerOptions](https://github.com/apollographql/apollo-server/blob/master/packages/apollo-server-core/src/graphqlOptions.ts#L7-L16) from Apollo.
 ```js
-options.graphql = { schema }
+options.graphql = { schema, rootValue }
 ```
 
 ### GraphiQL


### PR DESCRIPTION
`rootValue` is optional, but your GraphQL server would be useless without it!