### PR TITLE
Change fastify perfix version to 0.35

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ const fp = plugin =>
     })
 
     next()
-  }, '^0.30')
+  }, '^0.35')
 
 function plugin (fastify, { graphql, graphiql, printSchema }, next) {
   fastify

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "fastify-plugin": "^0.1.1"
   },
   "devDependencies": {
-    "fastify": "^0.30.2",
+    "fastify": "^0.35.0",
     "graphql": "^0.11.7",
     "graphql-tools": "^1.2.3",
     "request": "^2.83.0",

--- a/test.js
+++ b/test.js
@@ -4,6 +4,7 @@ const test = require('tap').test
 const fastify = require('fastify')
 const makeExecutableSchema = require('graphql-tools').makeExecutableSchema
 const request = require('request')
+const fastifyApollo = require('./index')
 
 const typeDefs = `
 type Query {
@@ -33,7 +34,7 @@ test('GET /graphql', t => {
 
   const server = fastify()
 
-  server.register(require('./index'), opts)
+  server.register(fastifyApollo, opts)
 
   server.listen(0, err => {
     t.error(err)
@@ -54,7 +55,7 @@ test('POST /graphql', t => {
 
   const server = fastify()
 
-  server.register(require('./index'), opts)
+  server.register(fastifyApollo, opts)
 
   server.listen(0, err => {
     t.error(err)
@@ -85,7 +86,7 @@ test('POST /graphql (error)', t => {
 
   const server = fastify()
 
-  server.register(require('./index'), opts)
+  server.register(fastifyApollo, opts)
 
   server.listen(0, err => {
     t.error(err)
@@ -116,7 +117,7 @@ test('GET /graphiql (options as boolean)', t => {
 
   const server = fastify()
 
-  server.register(require('./index'), opts)
+  server.register(fastifyApollo, opts)
 
   server.listen(0, err => {
     t.error(err)
@@ -138,7 +139,7 @@ test('GET /graphiql (options as object)', t => {
 
   const server = fastify()
 
-  server.register(require('./index'), opts)
+  server.register(fastifyApollo, opts)
 
   server.listen(0, err => {
     t.error(err)
@@ -160,7 +161,7 @@ test('GET /schema', t => {
 
   const server = fastify()
 
-  server.register(require('./index'), Object.assign({}, opts, {
+  server.register(fastifyApollo, Object.assign({}, opts, {
     printSchema: true
   }))
 
@@ -180,11 +181,11 @@ test('GET /schema', t => {
 })
 
 test('prefix', t => {
-  t.plan(3)
+  t.plan(4)
 
   const server = fastify()
 
-  server.register(require('./index'), Object.assign({}, {
+  server.register(fastifyApollo, Object.assign({}, opts, {
     prefix: '/api',
     printSchema: true
   }))


### PR DESCRIPTION
After taking a look at the changelog from 0.30 until 0.35 looks like they didn't change anything on the plugin API. 

According to [this issue](https://github.com/coopnd/fastify-apollo/issues/9) I updated to the latest fastify version.

I didn't test it manually, but the tests are passing, shouldn't affect the functionality of the package. 